### PR TITLE
Fix icons when compiled into a release

### DIFF
--- a/lib/ex_effective_bootstrap/icons.ex
+++ b/lib/ex_effective_bootstrap/icons.ex
@@ -6,8 +6,6 @@ defmodule ExEffectiveBootstrap.Icons do
   """
   alias ExEffectiveBootstrap.Options
 
-  @svg_path "deps/ex_effective_bootstrap/priv/icons"
-
   # icon(:check, class: 'big-4')
   # icon('check', class: 'small-3')
   @spec icon(atom | String.t(), Keyword.t()) :: Phoenix.HTML.Safe.t()
@@ -18,8 +16,10 @@ defmodule ExEffectiveBootstrap.Icons do
       |> Enum.map(fn {key, value} -> "#{key}='#{value}'" end)
       |> Enum.join(" ")
 
+    svg_path = Application.app_dir(:ex_effective_bootstrap, ["priv", "icons"])
+
     svg_tag =
-      File.read!("#{@svg_path}/#{svg}.svg")
+      File.read!("#{svg_path}/#{svg}.svg")
       |> String.replace("svg", "svg #{opts}", global: false)
 
     {:safe, svg_tag}


### PR DESCRIPTION
Things go horribly awry when an app using `ex_effective_icons` is compiled into a release. When an input that uses an icon is rendered, or any other use of an icon, the app will throw a stack trace because it is unable to find the svg path that is hardcoded into the `Icons` module. This fixes that problem.